### PR TITLE
Feature grammar fixes: feature name, newline token

### DIFF
--- a/de.sebastianbenz.xgherkin/src/de/sebastianbenz/xgherkin/Gherkin.xtext
+++ b/de.sebastianbenz.xgherkin/src/de/sebastianbenz/xgherkin/Gherkin.xtext
@@ -97,7 +97,7 @@ OptionalText returns ecore::EString:
 terminal EXAMPLE_HEADING: 'Examples' SPACES ':' SPACES '\r'? '\n';
 
 terminal fragment NNL: !('\r' | '\n');
-terminal fragment NL: '\r'? '\n'?;
+terminal fragment NL: '\r'? '\n';
 terminal fragment SPACES: (' '|'\t')*;
 terminal FEATURE_TEXT: ('Narrative:' | 'Feature:') NNL* NL;
 

--- a/de.sebastianbenz.xgherkin/src/de/sebastianbenz/xgherkin/Gherkin.xtext
+++ b/de.sebastianbenz.xgherkin/src/de/sebastianbenz/xgherkin/Gherkin.xtext
@@ -6,7 +6,7 @@ import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
 Feature:
 	tags+=TAG*
-	name=FEATURE_TEXT?
+	name=FEATURE_TEXT
 	elements+=NarrativeElement*
 	scenarios+=AbstractScenario*
 ;


### PR DESCRIPTION
This PR fixes the followinf:

 * Feature name in a feature file is required (Xtext/ANTLR ambiguity warning)
 * Fix newline token in feature grammar (Xtext/ANTLR error)